### PR TITLE
Add missing name for paste body field on clone page

### DIFF
--- a/assets/clone.html
+++ b/assets/clone.html
@@ -38,7 +38,7 @@
 						</div>
 
 						<div class="form-group is-empty" style="margin-top: 0px;">
-							<textarea class="form-control" rows="20" id="textArea" data-autoresize>{{printf "%s" .Body}}</textarea>
+							<textarea class="form-control" rows="20" id="textArea" name="p" data-autoresize>{{printf "%s" .Body}}</textarea>
 							<span class="help-block">Paste your text here</span>
 						</div>
 					</div>


### PR DESCRIPTION
The `name="p"` part is present in index but not the clone page. Without the change I am getting "Empty paste" when submitting any paste from the clone page.
